### PR TITLE
feat: add option for minimum timeout

### DIFF
--- a/client.js
+++ b/client.js
@@ -2,6 +2,7 @@ import Backoff from 'backo2'
 import EventEmitter from 'eventemitter3'
 import $$observable from 'symbol-observable'
 
+const WS_MINTIMEOUT = 1000
 const WS_TIMEOUT = 30000
 
 function isString(value) {
@@ -16,6 +17,7 @@ export class SubscriptionClient {
     const {
       connectionCallback = undefined,
       connectionParams = {},
+      minTimeout = WS_MINTIMEOUT,
       timeout = WS_TIMEOUT,
       reconnect = false,
       reconnectionAttempts = Infinity,
@@ -28,6 +30,7 @@ export class SubscriptionClient {
     this.url = url
     this.operations = {}
     this.nextOperationId = 0
+    this.wsMinTimeout = minTimeout
     this.wsTimeout = timeout
     this.unsentMessagesQueue = []
     this.reconnect = reconnect
@@ -207,7 +210,7 @@ export class SubscriptionClient {
   }
 
   createMaxConnectTimeGenerator() {
-    const minValue = 1000
+    const minValue = this.wsMinTimeout
     const maxValue = this.wsTimeout
     return new Backoff({
       min: minValue,


### PR DESCRIPTION
**Issue**
The minimum timeout on initial connection before closing and attempting to reconnect is 1000ms. In some cases, the GraphQL server may routinely take longer than 1000ms to establish the connection, and in this case will go through a series of reconnections on every new websocket until the `maxConnectionTime` has incremented sufficiently. This delays the initial connection.

**New feature**
This PR adds a `minTimeout` option to set the minimum amount of time the client should wait for a connection to be made.

This is a non-breaking change:

- Default remains at 1000ms when `minTimeout` is not specified
- `apollographql/subscriptions-transport-ws` also has a `minTimeout` option, so this is consistent with that library
