### PR TITLE
feat: added typescript types

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -1,0 +1,101 @@
+import { ListenerFn } from "eventemitter3"
+import { ExecutionResult } from "graphql/execution/execute"
+
+export interface Observer<T> {
+  next?: (value: T) => void
+  error?: (error: Error) => void
+  complete?: () => void
+}
+
+export interface Observable<T> {
+  subscribe(
+    observer: Observer<T>
+  ): {
+    unsubscribe: () => void
+  }
+}
+
+export interface OperationOptions {
+  query: string
+  variables?: Object
+  operationName?: string
+  [key: string]: any
+}
+
+export declare type ConnectionParams = {
+  [paramName: string]: any
+}
+
+export declare type ConnectionParamsOptions =
+  | ConnectionParams
+  | Function
+  | Promise<ConnectionParams>
+
+export interface ClientOptions {
+  connectionCallback?: (error: Error[], result?: any) => void
+  connectionParams?: ConnectionParamsOptions
+  minTimeout?: number
+  timeout?: number
+  reconnect?: boolean
+  reconnectionAttempts?: number
+  lazy?: boolean
+  inactivityTimeout?: number
+}
+
+export declare class SubscriptionClient {
+  private wsImpl
+  private connectionCallback
+  private url
+  private operations
+  private nextOperationId
+  private wsMinTimeout
+  private wsTimeout
+  private unsentMessagesQueue
+  private reconnect
+  private reconnecting
+  private reconnectionAttempts
+  private lazy
+  private inactivityTimeout
+  private closedByUser
+  private backoff
+  private eventEmitter
+  private client
+  private maxConnectTimeGenerator
+  private connectionParams
+
+  constructor(url: string, options?: ClientOptions)
+  get status(): any
+  close(isForced?: boolean, closedByUser?: boolean): void
+  request(request: OperationOptions): Observable<ExecutionResult>
+  on(eventName: string, callback: ListenerFn, context?: any): Function
+  onConnected(callback: ListenerFn, context?: any): Function
+  onConnecting(callback: ListenerFn, context?: any): Function
+  onDisconnected(callback: ListenerFn, context?: any): Function
+  onReconnected(callback: ListenerFn, context?: any): Function
+  onReconnecting(callback: ListenerFn, context?: any): Function
+  onError(callback: ListenerFn, context?: any): Function
+  unsubscribeAll(): void
+
+  private getConnectionParams
+  private executeOperation
+  private getObserver
+  private createMaxConnectTimeGenerator
+  private clearCheckConnectionInterval
+  private clearMaxConnectTimeout
+  private clearTryReconnectTimeout
+  private clearInactivityTimeout
+  private setInactivityTimeout
+  private checkOperationOptions
+  private buildMessage
+  private formatErrors
+  private sendMessage
+  private sendMessageRaw
+  private generateOperationId
+  private tryReconnect
+  private flushUnsentMessagesQueue
+  private checkConnection
+  private checkMaxConnectTimeout
+  private connect
+  private processReceivedData
+  private unsubscribe
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-subscriptions-client",
-  "version": "0.12.0",
+  "version": "0.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13,6 +13,11 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+    },
+    "graphql": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz",
+      "integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w=="
     },
     "symbol-observable": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "graphql-subscriptions-client",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A simpler client for graphql subscriptions based on apollographql/subscriptions-transport-ws",
+  "types": "client.d.ts",
   "main": "client.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -18,6 +19,7 @@
   "dependencies": {
     "backo2": "^1.0.2",
     "eventemitter3": "^3.1.2",
+    "graphql": "^15.3.0",
     "symbol-observable": "^1.2.0"
   }
 }


### PR DESCRIPTION
**Issue**
I got tired of Typescript's complaints about not having a declaration file!

**New feature**
This PR add typings to the library. This makes it much friendlier, and safer for use, in Typescript projects.

I mostly adapted the types generated by the `apollographql/subscriptions-transport-ws` library, with a few minor changes:

- Removed some types that are unused and re-ordered others to match the source of this library
- Only allow `query` to be a `string`

Also added `graphql` as a dependency (as this provides the `ExecutionResult` type)

Non-breaking change.