### PR TITLE
convert to typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,21 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/node": {
+      "version": "14.11.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+      "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
+      "dev": true
+    },
+    "@types/ws": {
+      "version": "7.2.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.7.tgz",
+      "integrity": "sha512-UUFC/xxqFLP17hTva8/lVT0SybLUrfSD9c+iapKb0fEiC8uoDbA+xuZ3pAN603eW+bY8ebSMLm9jXdIPnD0ZgA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "ansi-styles": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
@@ -548,6 +563,11 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "ws": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,553 @@
 {
   "name": "graphql-subscriptions-client",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true,
+      "optional": true
+    },
+    "@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@types/backo2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/backo2/-/backo2-1.0.1.tgz",
+      "integrity": "sha512-teQyH3dwlHcnZ2HVQJ51sH1Duo8pI/wNXn6Bpse3ID9sVqpbd5eKQApGGAjYtb+6vlCGcEoXtaQW9/O8MJsdfQ==",
+      "dev": true
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+      "dev": true,
+      "requires": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      }
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
     "backo2": {
       "version": "1.0.2",
       "resolved": "http://registry.npm.taobao.org/backo2/download/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "cac": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.6.1.tgz",
+      "integrity": "sha512-uhki4T3Ax68hw7Dufi0bATVAF8ayBSwOKUEJHjObPrUN4tlQ8Lf7oljpTje/mArLxYN0D743c2zJt4C1bVTCqg==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "chokidar": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+      "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.4.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "esbuild": {
+      "version": "0.6.34",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.6.34.tgz",
+      "integrity": "sha512-InRdL/Q96pUucPqovJzvuLhquZr6jOn81FDVwFjCKz1rYKIm9OdOC+7Fs4vr6x48vKBl5LzKgtjU39BUpO636A==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "optional": true
     },
     "eventemitter3": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "joycon": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz",
+      "integrity": "sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ==",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "optional": true
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
+    "pirates": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+      "dev": true,
+      "requires": {
+        "node-modules-regexp": "^1.0.0"
+      }
+    },
+    "readdirp": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true
+    },
+    "rollup": {
+      "version": "2.28.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.28.2.tgz",
+      "integrity": "sha512-8txbsFBFLmm9Xdt4ByTOGa9Muonmc8MfNjnGAR8U8scJlF1ZW7AgNZa7aqBXaKtlvnYP/ab++fQIq9dB9NWUbg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.1.2"
+      }
+    },
+    "rollup-plugin-dts": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-1.4.13.tgz",
+      "integrity": "sha512-7mxoQ6PcmCkBE5ZhrjGDL4k42XLy8BkSqpiRi1MipwiGs+7lwi4mQkp2afX+OzzLjJp/TGM8llfe8uayIUhPEw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4"
+      }
+    },
+    "sucrase": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.15.0.tgz",
+      "integrity": "sha512-05TJOUfMgckH7wKqfk/1p4G6q16nIeW/GHQwD44vkT0mQMqqzgfHCwkX3whNmwyOo7nVF0jDLwVu/qOBTtsscw==",
+      "dev": true,
+      "requires": {
+        "commander": "^4.0.0",
+        "glob": "7.1.6",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "http://registry.npm.taobao.org/symbol-observable/download/symbol-observable-1.2.0.tgz",
       "integrity": "sha1-wiaIrtTqs83C3+rLtWFmBWCgCAQ="
+    },
+    "thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "dev": true,
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
+    },
+    "tsup": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-3.7.0.tgz",
+      "integrity": "sha512-OV6/mpHL/5W8ba1W1qXPpOiWQzELrutxfM3LTCAi2WUPALaM4RirH65G6V4n9bhJ+6MCRZ2TMuAmz9SOJKuIwg==",
+      "dev": true,
+      "requires": {
+        "cac": "^6.6.1",
+        "chalk": "^4.1.0",
+        "chokidar": "^3.4.2",
+        "esbuild": "^0.6.19",
+        "joycon": "^2.2.5",
+        "resolve-from": "^5.0.0",
+        "rollup": "^2.26.11",
+        "rollup-plugin-dts": "^1.4.10",
+        "sucrase": "^3.15.0"
+      }
+    },
+    "typescript": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "graphql-subscriptions-client",
   "version": "0.13.0",
   "description": "A simpler client for graphql subscriptions based on apollographql/subscriptions-transport-ws",
+  "module": "dist/esm/index.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "build": "rm -rf dist && tsup src/index.ts --format esm,cjs,iife --legacy-output --dts",
     "prepublishOnly": "npm run build",
+    "prepare": "npm run build",
+    "prepack": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -2,12 +2,17 @@
   "name": "graphql-subscriptions-client",
   "version": "0.13.0",
   "description": "A simpler client for graphql subscriptions based on apollographql/subscriptions-transport-ws",
-  "main": "client.js",
+  "main": "dist/index.js",
   "scripts": {
+    "build": "rm -rf dist && tsup src/index.ts --format esm,cjs,iife --legacy-output --dts",
+    "prepublishOnly": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
     "graphql"
+  ],
+  "files": [
+    "dist"
   ],
   "author": "James Smith",
   "license": "MIT",
@@ -19,5 +24,10 @@
     "backo2": "^1.0.2",
     "eventemitter3": "^3.1.2",
     "symbol-observable": "^1.2.0"
+  },
+  "devDependencies": {
+    "@types/backo2": "^1.0.1",
+    "tsup": "^3.7.0",
+    "typescript": "^4.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,10 +25,12 @@
   "dependencies": {
     "backo2": "^1.0.2",
     "eventemitter3": "^3.1.2",
-    "symbol-observable": "^1.2.0"
+    "symbol-observable": "^1.2.0",
+    "ws": "^7.3.1"
   },
   "devDependencies": {
     "@types/backo2": "^1.0.1",
+    "@types/ws": "^7.2.7",
     "tsup": "^3.7.0",
     "typescript": "^4.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.13.0",
   "description": "A simpler client for graphql subscriptions based on apollographql/subscriptions-transport-ws",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && tsup src/index.ts --format esm,cjs,iife --legacy-output --dts",
     "prepublishOnly": "npm run build",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+/// <reference lib="dom" />
 import Backoff from 'backo2'
 import EventEmitter, { ListenerFn }  from 'eventemitter3'
 import $$observable from 'symbol-observable'
@@ -164,7 +165,7 @@ export class SubscriptionClient {
       [$$observable]() {
         return this
       },
-      subscribe(observerOrNext, onError, onComplete) {
+      subscribe(observerOrNext, onError?, onComplete?) {
         const observer = getObserver(observerOrNext, onError, onComplete)
         opId = executeOperation(request, (error, result) => {
           if (error === null && result === null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,89 @@
 import Backoff from 'backo2'
-import EventEmitter from 'eventemitter3'
+import EventEmitter, { ListenerFn }  from 'eventemitter3'
 import $$observable from 'symbol-observable'
 
 const WS_MINTIMEOUT = 1000
 const WS_TIMEOUT = 30000
 
-function isString(value) {
-  return typeof value === 'string'
+const isString = (value: unknown): value is string => typeof value === 'string';
+const isObject = (value: unknown): value is object => value !== null && typeof value === 'object';
+
+export interface OperationOptions {
+  query: string
+  variables?: Object
+  operationName?: string
+  [key: string]: any
 }
-function isObject(value) {
-  return value !== null && typeof value === 'object'
+
+export interface Observer<T> {
+  next?: (value: T) => void
+  error?: (error: Error) => void
+  complete?: () => void
+}
+
+export interface Observable<T> {
+  subscribe(
+    observer: Observer<T>
+  ): {
+    unsubscribe: () => void
+  }
+}
+
+
+interface Operations {
+  [key: string]: {
+    options: OperationOptions,
+    handler: (error: Error, data: unknown) => any
+  }
+}
+
+export declare type ConnectionParams = {
+  [paramName: string]: unknown
+}
+
+export declare type ConnectionParamsOptions =
+   | ConnectionParams
+   | Function
+   | Promise<ConnectionParams>
+
+export interface ClientOptions {
+  connectionCallback?: (error: Error[], result?: unknown) => void
+  connectionParams?: ConnectionParamsOptions
+  minTimeout?: number
+  timeout?: number
+  reconnect?: boolean
+  reconnectionAttempts?: number
+  lazy?: boolean
+  inactivityTimeout?: number
 }
 
 export class SubscriptionClient {
-  constructor(url, options) {
+  private wsImpl: typeof WebSocket;
+  private connectionCallback;
+  private url: string;
+  private operations: Operations;
+  private nextOperationId: number;
+  private wsMinTimeout: number;
+  private wsTimeout: number;
+  private unsentMessagesQueue: unknown[];
+  private reconnect: boolean;
+  private reconnecting: boolean;
+  private reconnectionAttempts: number;
+  private lazy: boolean;
+  private inactivityTimeout: number;
+  private closedByUser: boolean;
+  private backoff: Backoff;
+  private eventEmitter: EventEmitter;
+  private client: WebSocket;
+  private maxConnectTimeGenerator: Backoff;
+  private connectionParams: () => Promise<any>;
+  private checkConnectionIntervalId: number;
+  private maxConnectTimeoutId: number;
+  private tryReconnectTimeoutId: number;
+  private inactivityTimeoutId: number;
+  private wasKeepAliveReceived: boolean;
+
+  constructor(url: string, options: ClientOptions) {
     const {
       connectionCallback = undefined,
       connectionParams = {},
@@ -50,7 +120,7 @@ export class SubscriptionClient {
     }
   }
 
-  get status() {
+  get status(): number {
     if (this.client === null) {
       return this.wsImpl.CLOSED
     }
@@ -81,7 +151,7 @@ export class SubscriptionClient {
     }
   }
 
-  request(request) {
+  request(request: OperationOptions) {
     const getObserver = this.getObserver.bind(this)
     const executeOperation = this.executeOperation.bind(this)
     const unsubscribe = this.unsubscribe.bind(this)
@@ -124,34 +194,34 @@ export class SubscriptionClient {
     }
   }
 
-  on(eventName, callback, context) {
+  on(eventName: string, callback: ListenerFn, context: unknown) {
     const handler = this.eventEmitter.on(eventName, callback, context)
     return () => {
       handler.off(eventName, callback, context)
     }
   }
 
-  onConnected(callback, context) {
+  onConnected(callback: ListenerFn, context: unknown) {
     return this.on('connected', callback, context)
   }
 
-  onConnecting(callback, context) {
+  onConnecting(callback: ListenerFn, context: unknown) {
     return this.on('connecting', callback, context)
   }
 
-  onDisconnected(callback, context) {
+  onDisconnected(callback: ListenerFn, context: unknown) {
     return this.on('disconnected', callback, context)
   }
 
-  onReconnected(callback, context) {
+  onReconnected(callback: ListenerFn, context: unknown) {
     return this.on('reconnected', callback, context)
   }
 
-  onReconnecting(callback, context) {
+  onReconnecting(callback: ListenerFn, context: unknown) {
     return this.on('reconnecting', callback, context)
   }
 
-  onError(callback, context) {
+  onError(callback: ListenerFn, context: unknown) {
     return this.on('error', callback, context)
   }
 
@@ -161,12 +231,12 @@ export class SubscriptionClient {
     })
   }
 
-  getConnectionParams(connectionParams) {
-    return () =>
-      new Promise((resolve, reject) => {
+  getConnectionParams(connectionParams: Function | { [key: string]: any }) {
+    return () => {
+      return new Promise((resolve, reject) => {
         if (typeof connectionParams === 'function') {
           try {
-            return resolve(connectionParams(null))
+            return resolve(connectionParams())
           } catch (error) {
             return reject(error)
           }
@@ -174,6 +244,7 @@ export class SubscriptionClient {
 
         resolve(connectionParams)
       })
+    }
   }
 
   executeOperation(options, handler) {
@@ -280,7 +351,7 @@ export class SubscriptionClient {
     }
   }
 
-  buildMessage(id, type, payload) {
+  buildMessage(id: string, type, payload) {
     const payloadToReturn =
       payload && payload.query
         ? Object.assign({}, payload, {
@@ -313,12 +384,12 @@ export class SubscriptionClient {
     ]
   }
 
-  sendMessage(id, type, payload) {
+  sendMessage(id: string | undefined, type: 'start' | 'stop' | 'connection_init' | 'connection_terminate' | 'connection_error', payload: any) {
     this.sendMessageRaw(this.buildMessage(id, type, payload))
   }
 
   // send message, or queue it if connection is not open
-  sendMessageRaw(message) {
+  sendMessageRaw(message: any) {
     switch (this.status) {
       case this.wsImpl.OPEN:
         const serializedMessage = JSON.stringify(message)
@@ -448,7 +519,7 @@ export class SubscriptionClient {
     })
   }
 
-  processReceivedData(receivedData) {
+  processReceivedData(receivedData: string) {
     let parsedMessage
     let opId
 
@@ -532,7 +603,7 @@ export class SubscriptionClient {
     }
   }
 
-  unsubscribe(opId) {
+  unsubscribe(opId: string) {
     if (this.operations[opId]) {
       delete this.operations[opId]
       this.setInactivityTimeout()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "moduleResolution": "node",
+        "allowSyntheticDefaultImports": true
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
     "compilerOptions": {
         "moduleResolution": "node",
-        "allowSyntheticDefaultImports": true
+        "allowSyntheticDefaultImports": true,
+        "noImplicitAny": true,
+        "target": "es2020"
     }
 }


### PR DESCRIPTION
Converts the whole lib to use typescript it's a little more of a change than https://github.com/lunchboxer/graphql-subscriptions-client/pull/6 but it should make it easier to keep the types up to date.

To build the js files just run `npm run build`.